### PR TITLE
Discount 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,31 +55,36 @@ Example
 Options
 -------
 
-Option          | Action
-----------------|------------------------------------------
-toc             | Enable table of contents
-nolinks         | Disable links and disallow `<a>` tags
-noimages        | Disable images and disallow `<img>` tags
-nopants         | Disable [SmartyPants]
-nohtml          | Don't allow raw HTML at all
-strict          | Disable superscript and relaxed emphasis
-tagtext         | Process text inside html tags
-noext           | Disable [pseudo-protocols]
-cdata           | Generate code for XML (using `![CDATA[...]]`)
-nosuperscript   | Disable superscript (`A^B`)
-norelaxed       | Emphasis happens *everywhere*
-notables        | Disable [PHP Markdown Extra] style [tables]
-nostrikethrough | Disable `~~strikethrough~~`
-compat          | Compatability with MarkdownTest_1.0
-autolink        | Turn URLs into links, even without enclosing angle brackets
-safelink        | Paranoid check for link protocol
-noheader        | Disable [Pandoc] style [headers]
-tabstop         | Expand tabs to 4 spaces
-nodivquote      | Disable `>%class%` blocks
-noalphalist     | Disable alphabetic lists
-nodlist         | Disable definition lists
-extrafootnote   | Enable [PHP Markdown Extra] style [footnotes]
-embed           | Equivalent to combining `nolinks`, `noimages` and `tagtext`
+Option           | Action
+-----------------|------------------------------------------
+nolinks          | Disable links and disallow `<a>` tags
+noimages         | Disable images and disallow `<img>` tags
+nopants          | Disable [SmartyPants]
+nohtml           | Don't allow raw HTML at all
+strict           | Disable superscript and relaxed emphasis
+tagtext          | Process text inside html tags
+noext            | Disable [pseudo-protocols]
+cdata            | Generate code for XML (using `![CDATA[...]]`)
+nosuperscript    | Disable superscript (`A^B`)
+notables         | Disable [PHP Markdown Extra] style [tables]
+nostrikethrough  | Disable `~~strikethrough~~`
+toc              | Enable table of contents
+compat           | Compatability with MarkdownTest_1.0
+autolink         | Turn URLs into links, even without enclosing angle brackets
+safelink         | Paranoid check for link protocol
+noheader         | Disable [Pandoc] style [headers]
+tabstop          | Expand tabs to 4 spaces
+nodivquote       | Disable `>%class%` blocks
+noalphalist      | Disable alphabetic lists
+nodlist          | Disable definition lists
+nodldiscount     | Disable discount-style definition lists
+dlextra          | Enable extra-style definition lists
+extrafootnote    | Enable [PHP Markdown Extra] style [footnotes]
+nostyle          | Don't extract `<style>` blocks from the output
+fencedcode       | Allow fenced code blocks
+idanchor         | Use `id=` anchors for table-of contents links instead of `<a name=/>`
+githubtags       | Allow underscore and dash in passed through element names
+urlencodedanchor | Use url-encoded chars for multibuyte and nonalphanumeric chars rather than dots in toc links
 
 [License]
 ---------

--- a/discount.c
+++ b/discount.c
@@ -22,18 +22,20 @@
 
 static const char *const options[] = {
     "nolinks", "noimages", "nopants", "nohtml", "strict",
-    "tagtext", "noext", "cdata", "nosuperscript", "norelaxed",
-    "notables", "nostrikethrough", "toc", "compat", "autolink",
-    "safelink", "noheader", "tabstop", "nodivquote",
-    "noalphalist", "nodlist", "extrafootnote", "embed", NULL
+    "tagtext", "noext", "cdata", "nosuperscript", "notables",
+    "nostrikethrough", "toc", "compat", "autolink", "safelink",
+    "noheader", "tabstop", "nodivquote", "noalphalist", "nodlist",
+    "nodldiscount", "dlextra", "extrafootnote", "nostyle",
+    "fencedcode", "idanchor", "githubtags", "urlencodedanchor", NULL
 };
 
 static const int option_codes[] = {
     MKD_NOLINKS, MKD_NOIMAGE, MKD_NOPANTS, MKD_NOHTML, MKD_STRICT,
-    MKD_TAGTEXT, MKD_NO_EXT, MKD_CDATA, MKD_NOSUPERSCRIPT, MKD_NORELAXED,
-    MKD_NOTABLES, MKD_NOSTRIKETHROUGH, MKD_TOC, MKD_1_COMPAT, MKD_AUTOLINK,
-    MKD_SAFELINK, MKD_NOHEADER, MKD_TABSTOP, MKD_NODIVQUOTE,
-    MKD_NOALPHALIST, MKD_NODLIST, MKD_EXTRA_FOOTNOTE, MKD_EMBED
+    MKD_TAGTEXT, MKD_NO_EXT, MKD_CDATA, MKD_NOSUPERSCRIPT, MKD_NOTABLES,
+    MKD_NOSTRIKETHROUGH, MKD_TOC, MKD_1_COMPAT, MKD_AUTOLINK, MKD_SAFELINK,
+    MKD_NOHEADER, MKD_TABSTOP, MKD_NODIVQUOTE, MKD_NOALPHALIST, MKD_NODLIST,
+    MKD_NODLDISCOUNT, MKD_DLEXTRA, MKD_EXTRA_FOOTNOTE, MKD_NOSTYLE,
+    MKD_FENCEDCODE, MKD_IDANCHOR, MKD_GITHUBTAGS, MKD_URLENCODEDANCHOR
 };
 
 static int push_error(lua_State *L, MMIOT *mm, const char *message) {


### PR DESCRIPTION
I've updated the flags in `discount.c` to match those in discount 2.2.1.
I've also updated the README to document the current flags.

If you're open to this, I'd also like to add further testing and try to better
advertise this module (on lua-l or wherever). It seems unfortunate to me
that this module hasn't been updated in a while and (even worse) that
the [more popular dicount bindings on LuaRocks](https://luarocks.org/modules/luarocks/lua-discount) hasn't been updated
since 2008.

Finally, I also wonder whether it would make sense to "pin" this module to
a specific version of discount by including the C source for a specific
version. I'm not entirely sure about the pros and cons of that versus your
way of doing things here.